### PR TITLE
Remove extra logToConsole = true line

### DIFF
--- a/lib/pusher_channels_flutter_web.dart
+++ b/lib/pusher_channels_flutter_web.dart
@@ -261,7 +261,6 @@ class PusherChannelsFlutterWeb {
     if (call.arguments['authorizer'] != null) {
       options.authorizer = allowInterop(onAuthorizer);
     }
-    Pusher.logToConsole = true;
     pusher = Pusher(call.arguments['apiKey'], options);
     pusher!.connection.bind('error', allowInterop(onError));
     pusher!.connection.bind('message', allowInterop(onMessage));


### PR DESCRIPTION
This is always overriding the value passed in by the user of the library