### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.0
+
+* [BREAKING CHANGE] Convert channel member to Map (instead of Set)
+* [FIXED] Add internal member before calling onMemberAdded callback on channel
+* [FIXED] onAuthorizer() doesn't work in Flutter web profile/release mode
+
 ## 1.0.5
 
 * [FIXED] Android: Subscribing to private channels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.0
+## 2.0.0
 
 * [BREAKING CHANGE] Convert channel member to Map (instead of Set)
 * [FIXED] Add internal member before calling onMemberAdded callback on channel

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pusher_channels_flutter
 description: Pusher Channels Flutter Plugin
-version: 1.0.5
+version: 1.1.0
 homepage: https://github.com/pusher/pusher-channels-flutter
 repository: https://github.com/pusher/pusher-channels-flutter
 issue_tracker: https://github.com/pusher/pusher-channels-flutter/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pusher_channels_flutter
 description: Pusher Channels Flutter Plugin
-version: 1.1.0
+version: 2.0.0
 homepage: https://github.com/pusher/pusher-channels-flutter
 repository: https://github.com/pusher/pusher-channels-flutter
 issue_tracker: https://github.com/pusher/pusher-channels-flutter/issues


### PR DESCRIPTION
[BREAKING CHANGE] Convert channel member to Map (instead of Set)
[FIXED] Add internal member before calling onMemberAdded callback on channel
[FIXED] onAuthorizer() doesn't work in Flutter web profile/release mode