### PR TITLE
Replace FlutterActivity with general Activity

### DIFF
--- a/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
@@ -11,7 +11,6 @@ import com.pusher.client.connection.ConnectionStateChange
 import com.pusher.client.util.HttpAuthorizer
 import io.flutter.Log
 import android.app.Activity
-import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -27,7 +26,7 @@ class PusherChannelsFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAw
     ConnectionEventListener, ChannelEventListener, SubscriptionEventListener,
     PrivateChannelEventListener, PrivateEncryptedChannelEventListener, PresenceChannelEventListener,
     Authorizer {
-    private var activity: FlutterFragmentActivity? = null
+    private var activity: Activity? = null
     private lateinit var methodChannel: MethodChannel
     private var pusher: Pusher? = null
     private val TAG = "PusherChannelsFlutter"
@@ -42,11 +41,11 @@ class PusherChannelsFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAw
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-        activity = binding.activity as FlutterFragmentActivity
+        activity = binding.activity as Activity
     }
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-        activity = binding.activity as FlutterFragmentActivity
+        activity = binding.activity as Activity
     }
 
     override fun onDetachedFromActivityForConfigChanges() {

--- a/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
@@ -10,7 +10,6 @@ import com.pusher.client.connection.ConnectionState
 import com.pusher.client.connection.ConnectionStateChange
 import com.pusher.client.util.HttpAuthorizer
 import io.flutter.Log
-import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -26,7 +25,7 @@ class PusherChannelsFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAw
     ConnectionEventListener, ChannelEventListener, SubscriptionEventListener,
     PrivateChannelEventListener, PrivateEncryptedChannelEventListener, PresenceChannelEventListener,
     Authorizer {
-    private var activity: FlutterActivity? = null
+    private var activity: Activity? = null
     private lateinit var methodChannel: MethodChannel
     private var pusher: Pusher? = null
     private val TAG = "PusherChannelsFlutter"
@@ -41,11 +40,11 @@ class PusherChannelsFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAw
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-        activity = binding.activity as FlutterActivity
+        activity = binding.activity as Activity
     }
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-        activity = binding.activity as FlutterActivity
+        activity = binding.activity as Activity
     }
 
     override fun onDetachedFromActivityForConfigChanges() {

--- a/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
@@ -11,6 +11,7 @@ import com.pusher.client.connection.ConnectionStateChange
 import com.pusher.client.util.HttpAuthorizer
 import io.flutter.Log
 import android.app.Activity
+import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -26,7 +27,7 @@ class PusherChannelsFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAw
     ConnectionEventListener, ChannelEventListener, SubscriptionEventListener,
     PrivateChannelEventListener, PrivateEncryptedChannelEventListener, PresenceChannelEventListener,
     Authorizer {
-    private var activity: Activity? = null
+    private var activity: FlutterFragmentActivity? = null
     private lateinit var methodChannel: MethodChannel
     private var pusher: Pusher? = null
     private val TAG = "PusherChannelsFlutter"
@@ -41,11 +42,11 @@ class PusherChannelsFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAw
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-        activity = binding.activity as Activity
+        activity = binding.activity as FlutterFragmentActivity
     }
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-        activity = binding.activity as Activity
+        activity = binding.activity as FlutterFragmentActivity
     }
 
     override fun onDetachedFromActivityForConfigChanges() {

--- a/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
@@ -10,6 +10,7 @@ import com.pusher.client.connection.ConnectionState
 import com.pusher.client.connection.ConnectionStateChange
 import com.pusher.client.util.HttpAuthorizer
 import io.flutter.Log
+import android.app.Activity
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding


### PR DESCRIPTION
Hello there, 
As I was trying to use the library, there were some bugs when trying to implement other dependencies, such as local_auth, or flutter_stripe, Both require the use of FlutterFragmentActivity. and since pusher was configured to use FlutterActivity, it was crashing the app. 
As I searched on your issues, I found this reference: [issue #45](https://github.com/pusher/pusher-channels-flutter/issues/45)
Where this error was already reported. not yet for local_auth. For context, on that issue it was mentioned FlutterFragmentActivity was deprecated, thus the pusher channel was not going to implement a fix. But after doing own research I believe the team was referencing the deprecated version, and the new one is very much in use by the flutter team and some of their native plugins, such as local_auth. [old one](https://api.flutter.dev/javadoc/io/flutter/app/FlutterFragmentActivity.html) vs [in use](https://api.flutter.dev/javadoc/io/flutter/embedding/android/FlutterFragmentActivity.html)

This is a simple fix that uses the parent Activity instead of the specific FlutterActivity, after testing, I saw it working with normal apps, and the one I am developing using local_auth. I saw a similar fix on other repos that had the same issues, such as [Flutter BArcode scanner](https://github.com/AmolGangadhare/flutter_barcode_scanner/pull/211/files)

I look forward to your thoughts, or if someone on the team could implement a better fix for this issue. As I did this one for a time constrained project, expecting a fix or better solution from the pusher team. Thanks for your help!