### PR TITLE
Swapping checks for private and private-encrypted channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+
+* [FIXED] Fix private-encrypted channels subscriptions
+
 ## 2.0.1
 * [FIXED] Change `getSocketId` function to return a `Future<String>`
 * [FIXED] Replace `FlutterActivity` with general Activity

--- a/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
@@ -140,10 +140,11 @@ class PusherChannelsFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAw
 
     private fun subscribe(channelName: String, result: Result) {
         val channel = when {
-            channelName.startsWith("private-") -> pusher!!.subscribePrivate(channelName, this)
             channelName.startsWith("private-encrypted-") -> pusher!!.subscribePrivateEncrypted(
                 channelName, this
             )
+            channelName.startsWith("private-") -> pusher!!.subscribePrivate(channelName, this)
+            
             channelName.startsWith("presence-") -> pusher!!.subscribePresence(
                 channelName, this
             )
@@ -160,9 +161,9 @@ class PusherChannelsFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAw
 
     private fun trigger(channelName: String, eventName: String, data: String, result: Result) {
         when {
+            channelName.startsWith("private-encrypted-") -> throw Exception("It's not currently possible to send a message using private encrypted channels.")
             channelName.startsWith("private-") -> pusher!!.getPrivateChannel(channelName)
                 .trigger(eventName, data)
-            channelName.startsWith("private-encrypted-") -> throw Exception("It's not currently possible to send a message using private encrypted channels.")
             channelName.startsWith("presence-") -> pusher!!.getPresenceChannel(channelName)
                 .trigger(eventName, data)
             else -> throw Exception("Messages can only be sent to private and presence channels.")

--- a/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
@@ -144,7 +144,6 @@ class PusherChannelsFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAw
                 channelName, this
             )
             channelName.startsWith("private-") -> pusher!!.subscribePrivate(channelName, this)
-            
             channelName.startsWith("presence-") -> pusher!!.subscribePresence(
                 channelName, this
             )

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pusher_channels_flutter
 description: Pusher Channels Flutter Plugin
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/pusher/pusher-channels-flutter
 repository: https://github.com/pusher/pusher-channels-flutter
 issue_tracker: https://github.com/pusher/pusher-channels-flutter/issues


### PR DESCRIPTION
## Description

This PR is based on @macpraveen [commit](https://github.com/macpraveen/pusher-channels-flutter/commit/9a07d94d00a9764cffad6671efe61b1ad19afb07) that fixes #59

Thanks, @macpraveen!

## CHANGELOG

* [FIXED] Fix private-encrypted channels subscriptions