### PR TITLE
Update web binding to return correct socket ID

### DIFF
--- a/lib/pusher_channels_flutter_web.dart
+++ b/lib/pusher_channels_flutter_web.dart
@@ -89,7 +89,7 @@ class PusherChannelsFlutterWeb {
         trigger(call);
         break;
       case 'getSocketId':
-        return pusher!.sessionID;
+        return pusher!.connection.socketId;
       default:
         throw PlatformException(
           code: 'Unimplemented',


### PR DESCRIPTION
## Description

The current web binding returns the session ID, which is as far as I can tell an internal value and is not the same as the socket ID, the Java and iOS binding do return the correct value.

## CHANGELOG

* [FIXED] Web: `getSocketId` now returns the socket ID instead of the session ID