### PR TITLE
Null check inside `PusherChannelsFlutterPlugin.callback`

### DIFF
--- a/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
@@ -87,7 +87,7 @@ class PusherChannelsFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAw
     }
 
     private fun callback(method: String, args: Any) {
-        activity!!.runOnUiThread {
+        activity?.runOnUiThread {
             methodChannel.invokeMethod(method, args)
         }
     }


### PR DESCRIPTION
## Description

Null-safety `!!` replaced by `?` inside `callback` method of `PusherChannelsFlutterPlugin` to call `activity.runOnUiThread`. Issue related: #91 

## CHANGELOG

* [CHANGED] Change call of `activity.runOnUiThread` to invoke `methodChannel`