### PR TITLE
Web: handle only PusherError type on onError callback function. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.2
+
+* [FIXED] Handle only  type on  callback function.
+
 ## 2.1.1
 
 * [CHANGED] Change call of activity.runOnUiThread to invoke methodChannel

--- a/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/pusher/channels_flutter/PusherChannelsFlutterPlugin.kt
@@ -226,7 +226,6 @@ class PusherChannelsFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAw
     }
 
     override fun onEvent(event: PusherEvent) {
-        // Log.i(TAG, "Received event with data: $event")
         callback(
             "onEvent", mapOf(
                 "channelName" to event.channelName,

--- a/lib/pusher_channels_flutter_web.dart
+++ b/lib/pusher_channels_flutter_web.dart
@@ -113,11 +113,14 @@ class PusherChannelsFlutterWeb {
 
   void onError(dynamic jsError) {
     final Map<String, dynamic> error = dartify<Map<String, dynamic>>(jsError);
-    methodChannel!.invokeMethod('onError', {
-      'message': error['data']?['message'],
-      'code': error['data']?['code'],
-      'error': error,
-    });
+
+    if (error['type'] == 'PusherError') {
+      methodChannel!.invokeMethod('onError', {
+        'message': error['data']?['message'],
+        'code': error['data']?['code'],
+        'error': error,
+      });
+    }
   }
 
   void onMessage(dynamic jsMessage) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pusher_channels_flutter
 description: Pusher Channels Flutter Plugin
-version: 2.1.1
+version: 2.1.2
 homepage: https://github.com/pusher/pusher-channels-flutter
 repository: https://github.com/pusher/pusher-channels-flutter
 issue_tracker: https://github.com/pusher/pusher-channels-flutter/issues


### PR DESCRIPTION
## Description

* Handle only `PusherError` type on `onError` callback function. 
* Fixes #82 

## CHANGELOG

* [FIXED] Handle only `PusherError` type on `onError` callback function.