### PR TITLE
Add Null Safety on Connect/Disconnect Pusher

### DIFF
--- a/ios/Classes/SwiftPusherChannelsFlutterPlugin.swift
+++ b/ios/Classes/SwiftPusherChannelsFlutterPlugin.swift
@@ -161,12 +161,12 @@ public class SwiftPusherChannelsFlutterPlugin: NSObject, FlutterPlugin, PusherDe
   }
 
   func connect(result: @escaping FlutterResult) {
-    pusher.connect()
+    pusher?.connect()
     result(nil)
   }
 
   func disconnect(result: @escaping FlutterResult) {
-    pusher.disconnect()
+    pusher?.disconnect()
     result(nil)
   }
 


### PR DESCRIPTION
## Pull Request: Add Null Safety to Pusher Connect/Disconnect Methods

### Summary

This PR enhances the stability of the **Pusher Channels Flutter plugin** by adding null safety to the `connect` and `disconnect` methods. It ensures the `pusher` instance is safely accessed, preventing potential runtime crashes.

### Changes Made

- Applied optional chaining to `pusher` in the following methods:
  - `connect(result:)`
    ```swift
    // Updated from:
    pusher.connect()

    // To:
    pusher?.connect()
    ```
  - `disconnect(result:)`
    ```swift
    // Updated from:
    pusher.disconnect()

    // To:
    pusher?.disconnect()
    ```

### Motivation

Previously, calling `connect()` or `disconnect()` without initializing the `pusher` instance could result in a crash. Adding null safety:
- Prevents unsafe access to `pusher`
- Improves plugin reliability
- Aligns with Swift best practices for handling optionals

### Testing

- Verified that calling `connect()` and `disconnect()` before initialization no longer causes crashes.
- Manually tested plugin behavior under various initialization states to confirm expected outcomes.

### Notes

- No changes were made to existing logic or external plugin behavior.
- This update is fully backward-compatible.
